### PR TITLE
Development

### DIFF
--- a/bin/fix_ploidy.py
+++ b/bin/fix_ploidy.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python
 
 """
-Fix ploidy for old variant database import in dragen 3.7+
+Fix ploidy for old variant database import in dragen 3.7+i
+
+Dragen 3.7 reports sex chromosomes as ploidy 1 instead of 2 which is fine except old variant database doesn't like
+
+Also dragen 3.7 phases variants which causes occasional fail with old variant database.
+
+
 """
 import argparse
 from pysam import VariantFile
@@ -22,34 +28,45 @@ bcf_in = VariantFile(input_vcf)
 
 new_file = open(output_vcf, 'w')
 
+
+# write header
 new_file.write(str(bcf_in.header))
 
+
+# loop through each variant
 for rec in bcf_in.fetch():
 	
+	# loop through each genotype
 	for sample in rec.samples:
 	
 		sample_gt = rec.samples[sample]['GT']
 		
+		# unphase
 		rec.samples[sample].phased = False
-			
+		
+		# if the genotype is missing and ploidy 2
 		if rec.samples[sample]['GT'] == (None, None):
 			
 			pass
 		
 		else:
 			
+			# sort genotype - e.g. 1/0 to 0/1 - old variant database is stupid and reads these wrong
 			rec.samples[sample]['GT'] = sorted((rec.samples[sample]['GT']))
-			
+		
+		# if ploidy 1
 		if len(sample_gt) ==1:
 			
+			# get ploidy one genotype
 			gt_val = rec.samples[sample]['GT'][0]
 			
+			# exception for missing ploidy 1 values
 			if rec.samples[sample]['GT'] == (None,):
 				
 				rec.samples[sample]['GT'] = (None, None)
 				
 			else:
-
+				# make ploidy 2 e.g. 1 > 1/1 and 0 to 0/0
 				rec.samples[sample]['GT'] = sorted((gt_val, gt_val))
 			
 	new_file.write(str(rec))

--- a/bin/fix_ploidy.py
+++ b/bin/fix_ploidy.py
@@ -27,15 +27,30 @@ new_file.write(str(bcf_in.header))
 for rec in bcf_in.fetch():
 	
 	for sample in rec.samples:
-				
+	
 		sample_gt = rec.samples[sample]['GT']
 		
-		# if ploidy is 1 e.g. X and Y then may ploidy 2 using whatever genotype is availible
+		rec.samples[sample].phased = False
+			
+		if rec.samples[sample]['GT'] == (None, None):
+			
+			pass
+		
+		else:
+			
+			rec.samples[sample]['GT'] = sorted((rec.samples[sample]['GT']))
+			
 		if len(sample_gt) ==1:
 			
 			gt_val = rec.samples[sample]['GT'][0]
 			
-			rec.samples[sample]['GT'] = (gt_val, gt_val)
+			if rec.samples[sample]['GT'] == (None,):
+				
+				rec.samples[sample]['GT'] = (None, None)
+				
+			else:
+
+				rec.samples[sample]['GT'] = sorted((gt_val, gt_val))
 			
 	new_file.write(str(rec))
 

--- a/bin/fix_ploidy.py
+++ b/bin/fix_ploidy.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+"""
+Fix ploidy for old variant database import in dragen 3.7+
+"""
+import argparse
+from pysam import VariantFile
+
+parser = argparse.ArgumentParser(description='Fix ploidy for old variant database import in dragen 3.7+')
+parser.add_argument('--input_vcf', type=str, nargs=1, required=True,
+				help='The input vcf')
+parser.add_argument('--output_vcf', type=str, nargs=1, required=True,
+				help='output vcf')
+
+
+args = parser.parse_args()
+
+input_vcf = args.input_vcf[0]
+output_vcf = args.output_vcf[0]
+
+bcf_in = VariantFile(input_vcf)  
+
+new_file = open(output_vcf, 'w')
+
+new_file.write(str(bcf_in.header))
+
+for rec in bcf_in.fetch():
+	
+	for sample in rec.samples:
+				
+		sample_gt = rec.samples[sample]['GT']
+		
+		# if ploidy is 1 e.g. X and Y then may ploidy 2 using whatever genotype is availible
+		if len(sample_gt) ==1:
+			
+			gt_val = rec.samples[sample]['GT'][0]
+			
+			rec.samples[sample]['GT'] = (gt_val, gt_val)
+			
+	new_file.write(str(rec))
+
+new_file.close()
+
+

--- a/dragenge_post_processing.nf
+++ b/dragenge_post_processing.nf
@@ -345,7 +345,7 @@ process create_vcf_for_old_variant_database{
         # source variables
         . \$i
         
-        echo \\#\\#SAMPLE\\=\\<ID\\=\$sampleId,Tissue\\=Germline,WorklistId\\="\$worklistId",SeqId\\="\$seqId",Assay\\="\$panel",PipelineName\\=germline_enrichment_nextflow,PipelineVersion\\="$params.pipeline_version"\\,RawSequenceQuality=0,PercentMapped=0,ATDropout=0,GCDropout=0,MeanInsertSize=0,SDInsertSize=0,DuplicationRate=0,TotalReads=0,PctSelectedBases=0,MeanOnTargetCoverage=0,PctTargetBasesCt=0,EstimatedContamination=0,GenotypicGender=None,TotalTargetedUsableBases=0,RemoteVcfFilePath=None,RemoteBamFilePath=None\\> >> ${params.sequencing_run}_meta.txt
+        echo \\#\\#SAMPLE\\=\\<ID\\=\$sampleId,Tissue\\=Germline,WorklistId\\="\$worklistId",SeqId\\="\$seqId",Assay\\="\$panel",PipelineName\\=dragenge_post_processing,PipelineVersion\\="$params.pipeline_version"\\,RawSequenceQuality=0,PercentMapped=0,ATDropout=0,GCDropout=0,MeanInsertSize=0,SDInsertSize=0,DuplicationRate=0,TotalReads=0,PctSelectedBases=0,MeanOnTargetCoverage=0,PctTargetBasesCt=0,EstimatedContamination=0,GenotypicGender=None,TotalTargetedUsableBases=0,RemoteVcfFilePath=None,RemoteBamFilePath=None\\> >> ${params.sequencing_run}_meta.txt
     done
 
     # get header 
@@ -354,8 +354,11 @@ process create_vcf_for_old_variant_database{
 
     zcat $vcf | grep -v "^##" >> ${params.sequencing_run}.roi.filtered.header.vcf
 
+
+    fix_ploidy.py --input_vcf ${params.sequencing_run}.roi.filtered.header.vcf --output_vcf ${params.sequencing_run}.roi.filtered.header.fixed.vcf
+
     # remove mt variants
-    awk '\$1 !~ /^MT/ { print \$0 }' ${params.sequencing_run}.roi.filtered.header.vcf > ${params.sequencing_run}_old_variant_database.vcf
+    awk '\$1 !~ /^MT/ { print \$0 }' ${params.sequencing_run}.roi.filtered.header.fixed.vcf > ${params.sequencing_run}_old_variant_database.vcf
 
     """
 }

--- a/dragenge_post_processing.nf
+++ b/dragenge_post_processing.nf
@@ -182,7 +182,7 @@ process normalise_annotate_with_vep_and_gnomad{
 
     output:
     set file("${params.sequencing_run}_anno.vcf.gz"), file("${params.sequencing_run}_anno.vcf.gz.tbi") into (annotated_vcf_relatedness_ch, annotated_vcf_samples_ch, annotated_vcf_reporting_ch)
-    file("${params.sequencing_run}.norm.anno.vcf.gz.md5")
+    file("${params.sequencing_run}_anno.vcf.gz.md5")
 
     """
     zcat $quality_vcf | vt decompose -s - | vt normalize -r $reference_genome - > ${params.sequencing_run}_norm.vcf
@@ -236,7 +236,7 @@ process normalise_annotate_with_vep_and_gnomad{
     bgzip ${params.sequencing_run}_anno.vcf
     tabix ${params.sequencing_run}_anno.vcf.gz
 
-    md5sum ${params.sequencing_run}_anno.vcf.gz > ${params.sequencing_run}.norm.anno.vcf.gz.md5
+    md5sum ${params.sequencing_run}_anno.vcf.gz > ${params.sequencing_run}_anno.vcf.gz.md5
     """
 }
 


### PR DESCRIPTION
Changes to resolve issues with dragen 3.7 VCFs interacting with old VariantDatabase

1) Dragen 3.7 VCFs report sex chromosome as ploidy 1 in males. This is more correct than previous VCF notation, but causes old variant database to error on first X/Y chromosome variant it encounters. This error was not detected during validation.

2) Old variant database does not like genotypes 1|0 - remove phasing information from vcf and switch around e.g. 1|0 > 0/1

3) Fix typo in name of md5sum file of annotated vcf

